### PR TITLE
WIP: Nix package. See notes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *~
 dist-newstyle/
 built/
+result/
+result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-All notable changes to this project will be documented in this file. This is
-mostly for the enduser.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-v0.1.0: The first release!

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+build:
+	export NIXPKGS_ALLOW_BROKEN=1
+	export LC_ALL=C.UTF-8
+	nix-build release.nix
+
+run: build
+	result/bin/burrow --source example-gopherhole --destination built --spacecookie
+
+repl:
+	nix-shell --pure shell.nix --run \
+		"cabal repl lib:burrow"
+
+shell:
+	nix-shell shell.nix
+
+shell-pure:
+	nix-shell --pure shell.nix
+
+external-shell:
+	nix-shell external.nix
+
+.PHONY: build run repl shell shell-pure external-shell

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ build:
 	export LC_ALL=C.UTF-8
 	nix-build release.nix
 
+regen:
+	nix-shell --pure -p cabal2nix --run "cabal2nix ." > default.nix
+
 run: build
 	result/bin/burrow --source example-gopherhole --destination built --spacecookie
 

--- a/burrow.cabal
+++ b/burrow.cabal
@@ -61,7 +61,7 @@ common shared-properties
     data-default,
     xml-conduit,
     word-wrap,
-    table-layout         ^>=0.9,
+    --table-layout         ^>=0.9,
     split,
     bytestring,
     containers,
@@ -127,17 +127,3 @@ library
 
   -- Directories containing source files.
   hs-source-dirs:      src
-
-test-suite waffle-test
-  import: shared-properties
-
-  -- The interface type and version of the test suite.
-  type:                exitcode-stdio-1.0
-
-  -- The directory where the test specifications are found.
-  hs-source-dirs:      test
-
-  -- The entrypoint to the test suite.
-  main-is:             DocTests.hs
-
-  build-depends:       doctest >= 0.16.3 && < 0.17,

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,33 @@
+{ mkDerivation, aeson, attoparsec, base, bytestring, commonmark
+, ConfigFile, containers, data-default, directory, errata, filepath
+, filepattern, frontmatter, fuzzy-dates, hashable, hourglass, lib
+, mtl, mustache, neat-interpolation, optparse-applicative, parsec
+, raw-strings-qq, split, text, time, unordered-containers, vector
+, word-wrap, xml-conduit, xml-conduit-writer, yaml
+}:
+mkDerivation {
+  pname = "burrow";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson attoparsec base bytestring commonmark ConfigFile containers
+    data-default directory errata filepath filepattern frontmatter
+    fuzzy-dates hashable hourglass mtl mustache neat-interpolation
+    optparse-applicative parsec raw-strings-qq split text time
+    unordered-containers vector word-wrap xml-conduit
+    xml-conduit-writer yaml
+  ];
+  executableHaskellDepends = [
+    aeson attoparsec base bytestring commonmark ConfigFile containers
+    data-default directory errata filepath filepattern frontmatter
+    fuzzy-dates hashable hourglass mtl mustache neat-interpolation
+    optparse-applicative parsec raw-strings-qq split text time
+    unordered-containers vector word-wrap xml-conduit
+    xml-conduit-writer yaml
+  ];
+  homepage = "https://github.com/hyperrealgopher/burrow";
+  description = "Build gopherholes";
+  license = lib.licenses.gpl3Only;
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,4 @@
+let
+  pkgs = import <nixpkgs> { };
+in
+  pkgs.haskellPackages.callPackage ./default.nix { }

--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,7 @@
 let
-  pkgs = import <nixpkgs> { };
+  config = { allowBroken = true; };
 in
-  pkgs.haskellPackages.callPackage ./default.nix { }
+  let
+    pkgs = (import <nixpkgs> { inherit config; }).pkgsStatic;
+  in
+    pkgs.haskellPackages.callPackage ./default.nix { }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+let
+  inherit (nixpkgs) pkgs;
+  inherit (pkgs) haskellPackages;
+
+  project = import ./release.nix;
+in
+pkgs.stdenv.mkDerivation {
+  name = "shell";
+  buildInputs = project.env.nativeBuildInputs ++ [
+    haskellPackages.cabal-install
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,6 @@
 { nixpkgs ? import <nixpkgs> {} }:
 let
-  inherit (nixpkgs) pkgs;
-  inherit (pkgs) haskellPackages;
-
+  inherit (nixpkgs) haskellPackages;
   project = import ./release.nix;
 in
 pkgs.stdenv.mkDerivation {

--- a/src/Phlog.hs
+++ b/src/Phlog.hs
@@ -64,6 +64,8 @@ data PostMeta = PostMeta
 
 -- FIXME: need beautiful errors informing a user of what is needed.
 -- only trigger this if it is post type?
+-- | Convert a `FileFrontMatter` pair to a `PostMeta` if all the required front
+-- matter is present.
 pairToPostMeta :: FileFrontMatter -> Maybe PostMeta
 pairToPostMeta (filePath, Just frontMatter) = Just $ PostMeta
   { metaPublished = fromJust $ fmPublished frontMatter
@@ -71,7 +73,7 @@ pairToPostMeta (filePath, Just frontMatter) = Just $ PostMeta
   , metaPath = T.pack filePath
   , metaTitle = fromJust $ fmTitle frontMatter
   , metaAuthor = fmAuthor frontMatter
-  -- ^ Can be Nothing because of default author entry in .ini
+  -- metaAuthor can be Nothing because of default author entry in .ini.
   , metaTags = fmTags frontMatter
   , metaFrontMatter = frontMatter
   }
@@ -236,12 +238,12 @@ instance PhlogIndex [PostMeta] MainPhlogIndex where
       _ <- ask
       pure $ postMetasPairs
 
+  -- | Create the main phlog index which includes all the posts sorted by date.
   renderIndexGophermap (MainPhlogIndex mainPhlogIndex) = do
     -- TODO: list main tag index
     -- TODO: 
     --  createDirectoryIfMissing True (takeDirectory mainTagIndexPath)
     -- FIXME: directories need to be defined in config
-    -- | Create the main phlog index which includes all the posts sorted by date.
     currentYear <- getCurrentYear
     configParser <- getConfig
     buildPath <- getConfigValue configParser "general" "buildPath"

--- a/src/TextUtils.hs
+++ b/src/TextUtils.hs
@@ -15,7 +15,7 @@ import Data.List.Split (chunksOf)
 
 import qualified Data.Text as Text
 
-import qualified Text.Layout.Table.Justify as Justify
+--import qualified Text.Layout.Table.Justify as Justify
 import Text.Wrap (WrapSettings(..), wrapTextToLines)
 
 
@@ -25,14 +25,8 @@ maxWidth :: Int
 maxWidth = 79
 
 
--- TODO: should hyphenate break long words
--- | Mustache-lambda-friendly function for text justification.
 justify2 :: Text.Text -> Text.Text
-justify2 text = Text.pack . unlines $ Justify.justifyText paragraphWidth (unlines wrappedLines)
- where
-  paragraphWidth = maxWidth
-  wrapSettings = WrapSettings { preserveIndentation = False, breakLongWords = True }
-  wrappedLines = map Text.unpack $ wrapTextToLines wrapSettings paragraphWidth text
+justify2 = justify'
 
 
 -- | The Mustache-lambda-friendly version of Burrow's custom text justification function.
@@ -42,9 +36,14 @@ justify' text = Text.pack . unlines $ justify (Text.unpack text)
 
 -- | Burrow's custom text justification function. Implemented for fun.
 justify :: String -> [String]
-justify string = map (flip addSpaceToNthWord 0) wrappedLines
+justify string = justify'' maxWidth string
+
+
+-- | Burrow's custom text justification function. Implemented for fun.
+justify'' :: Int -> String -> [String]
+justify'' maxWidth' string = map (flip addSpaceToNthWord 0) wrappedLines
  where
-  paragraphWidth = maxWidth
+  paragraphWidth = maxWidth'
   wrapSettings = WrapSettings { preserveIndentation = False, breakLongWords = True }
   wrappedLines = map Text.unpack $ wrapTextToLines wrapSettings paragraphWidth (Text.pack string)
 
@@ -83,6 +82,7 @@ justify string = map (flip addSpaceToNthWord 0) wrappedLines
         | otherwise = (x ++ [n]) : xs
 
 
+
 -- | Mustache-lambda-friendly version of the columnate function, meaning it has preconfigured
 -- column width, max width, and lines per column.
 columnate2 :: Text.Text -> Text.Text
@@ -109,7 +109,7 @@ columnate columnWidth totalMaxWidth maxLinesPerColumn textBlock = finalResult
   asSingleColumn =
     let wrapSettings = WrapSettings { preserveIndentation = False, breakLongWords = True } -- It's not breaking long words... should start using knuth's algo
         wrapped = wrapTextToLines wrapSettings columnWidth textBlock
-    in Text.unlines $ map (Text.justifyLeft columnWidth ' ') $ map Text.pack $ Justify.justifyText columnWidth (Text.unpack . Text.unlines $ wrapped)
+    in Text.unlines $ map (Text.justifyLeft columnWidth ' ') $ map Text.pack $ justify'' columnWidth (Text.unpack . Text.unlines $ wrapped)
 
   -- 2: Group the single justified column into text chunks of maxLinesPerColumn
   maxLinesGroups :: [[Text.Text]]


### PR DESCRIPTION
Begin the Nix packaging process.

I am new to Nix packaging.

I was having problems with getting table-layouts to work so I removed
the dependency entirely. I recall there being issues with this
dependency in the past and I was using it to justify text, but I have my
own function for doing that. So to temporarily save me the headache, in
order to get the package to build, I have removed that dependency.

I was following this guide to get my first release working:
https://maybevoid.com/posts/2019-01-27-getting-started-haskell-nix.html

When I change `burrow.cabal` I run: `nix-shell --pure -p cabal2nix --run
"cabal2nix ." > default.nix`. When I want to build the release I run
`nix-build release.nix`.

Also I had to use the envvar `NIXPKGS_ALLOW_BROKEN=1` to allow `errata`
to not halt the process.